### PR TITLE
Fix PaddingWrapper - PaddedChildrenList

### DIFF
--- a/lib/widgets/layouts/padded_widgets.dart
+++ b/lib/widgets/layouts/padded_widgets.dart
@@ -1,49 +1,72 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
+/// A customizable wrapper that applies padding to its child widget.
 class PaddingWrapper extends StatelessWidget {
   final Widget child;
-  final double? left;
-  final double? right;
-  final double? bottom;
-  final double? top;
-  final double defaultPadding;
+  final EdgeInsetsGeometry padding;
 
   const PaddingWrapper({
     super.key,
-    this.defaultPadding = 16.0, // Default padding value
-    this.left,
-    this.right,
-    this.bottom,
-    this.top,
     required this.child,
+    this.padding = const EdgeInsets.all(16.0), // Default padding value
   });
 
-  factory PaddingWrapper.symmetric({
-    double? vertical,
-    double? horizontal,
-    double defaultPadding = 16.0,
+  /// Factory constructor for applying the same padding to all sides.
+  factory PaddingWrapper.all({
     required Widget child,
+    double padding = 16.0,
   }) {
     return PaddingWrapper(
-      left: horizontal,
-      right: horizontal,
-      top: vertical,
-      bottom: vertical,
-      defaultPadding: defaultPadding,
+      padding: EdgeInsets.all(padding),
       child: child,
     );
   }
 
-  factory PaddingWrapper.all({
-    double padding = 16.0,
+  /// Factory constructor for symmetric padding (vertical and horizontal).
+  factory PaddingWrapper.symmetric({
     required Widget child,
+    double vertical = 16.0,
+    double horizontal = 16.0,
   }) {
     return PaddingWrapper(
-      left: padding,
-      right: padding,
-      top: padding,
-      bottom: padding,
-      defaultPadding: padding,
+      padding: EdgeInsets.symmetric(vertical: vertical, horizontal: horizontal),
+      child: child,
+    );
+  }
+
+  /// Factory constructor for specific padding on each side.
+  factory PaddingWrapper.only({
+    required Widget child,
+    double left = 16.0,
+    double right = 16.0,
+    double top = 0.0,
+    double bottom = 0.0,
+  }) {
+    return PaddingWrapper(
+      padding:
+          EdgeInsets.only(left: left, right: right, top: top, bottom: bottom),
+      child: child,
+    );
+  }
+
+  /// Factory constructor for horizontal padding only.
+  factory PaddingWrapper.horizontal({
+    required Widget child,
+    double horizontal = 16.0,
+  }) {
+    return PaddingWrapper(
+      padding: EdgeInsets.symmetric(horizontal: horizontal),
+      child: child,
+    );
+  }
+
+  /// Factory constructor for vertical padding only.
+  factory PaddingWrapper.vertical({
+    required Widget child,
+    double vertical = 16.0,
+  }) {
+    return PaddingWrapper(
+      padding: EdgeInsets.symmetric(vertical: vertical),
       child: child,
     );
   }
@@ -51,43 +74,81 @@ class PaddingWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: EdgeInsets.only(
-        left: left ?? defaultPadding,
-        right: right ?? defaultPadding,
-        bottom: bottom ?? 0,
-        top: top ?? 0,
-      ),
+      padding: padding,
       child: child,
     );
   }
 }
 
+/// A customizable list with padded children, providing default or custom padding.
 class PaddedChildrenList extends StatelessWidget {
   final List<Widget> children;
-  final EdgeInsetsGeometry? padding;
-
+  final EdgeInsetsGeometry padding;
   final MainAxisAlignment mainAxisAlignment;
   final CrossAxisAlignment crossAxisAlignment;
-  final double defaultPadding;
 
   const PaddedChildrenList({
     super.key,
     required this.children,
-    this.padding,
+    this.padding = const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 16.0),
     this.mainAxisAlignment = MainAxisAlignment.start,
     this.crossAxisAlignment = CrossAxisAlignment.start,
-    this.defaultPadding = 16.0, // Default padding value
   });
+
+  /// Factory constructor for default padding (all sides equal).
+  factory PaddedChildrenList.all({
+    required List<Widget> children,
+    double padding = 16.0,
+    MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
+    CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.start,
+  }) {
+    return PaddedChildrenList(
+      padding: EdgeInsets.all(padding),
+      mainAxisAlignment: mainAxisAlignment,
+      crossAxisAlignment: crossAxisAlignment,
+      children: children,
+    );
+  }
+
+  /// Factory constructor for symmetric padding (vertical and horizontal).
+  factory PaddedChildrenList.symmetric({
+    required List<Widget> children,
+    double vertical = 16.0,
+    double horizontal = 16.0,
+    MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
+    CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.start,
+  }) {
+    return PaddedChildrenList(
+      padding: EdgeInsets.symmetric(vertical: vertical, horizontal: horizontal),
+      mainAxisAlignment: mainAxisAlignment,
+      crossAxisAlignment: crossAxisAlignment,
+      children: children,
+    );
+  }
+
+  /// Factory constructor for custom padding (only specific sides).
+  factory PaddedChildrenList.only({
+    required List<Widget> children,
+    double left = 16.0,
+    double right = 16.0,
+    double top = 0.0,
+    double bottom = 16.0, // Ensure the bottom defaults to 16.0
+    MainAxisAlignment mainAxisAlignment = MainAxisAlignment.start,
+    CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.start,
+  }) {
+    return PaddedChildrenList(
+      padding:
+          EdgeInsets.only(left: left, right: right, top: top, bottom: bottom),
+      mainAxisAlignment: mainAxisAlignment,
+      crossAxisAlignment: crossAxisAlignment,
+      children: children,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      padding: padding ??
-          EdgeInsets.only(
-            left: defaultPadding,
-            right: defaultPadding,
-            bottom: defaultPadding,
-          ),
+      padding: padding,
       child: Column(
         mainAxisAlignment: mainAxisAlignment,
         crossAxisAlignment: crossAxisAlignment,

--- a/test/padded_widgets_test.dart
+++ b/test/padded_widgets_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:risto_widgets/widgets/layouts/padded_widgets.dart';
+
+void main() {
+  group('PaddingWrapper', () {
+    testWidgets('PaddingWrapper applies default padding',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: PaddingWrapper(
+            child: Text('Test'),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(padding.padding, const EdgeInsets.all(16.0)); // Default padding
+    });
+
+    testWidgets('PaddingWrapper applies all side padding',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PaddingWrapper.all(
+            padding: 20.0,
+            child: const Text('Test'),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(padding.padding, const EdgeInsets.all(20.0)); // Custom padding
+    });
+
+    testWidgets('PaddingWrapper applies symmetric padding',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PaddingWrapper.symmetric(
+            vertical: 10.0,
+            horizontal: 20.0,
+            child: const Text('Test'),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(padding.padding,
+          const EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0));
+    });
+
+    testWidgets('PaddingWrapper applies individual padding',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PaddingWrapper.only(
+            left: 10.0,
+            top: 20.0,
+            child: const Text('Test'),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(
+          padding.padding,
+          const EdgeInsets.only(
+              left: 10.0,
+              top: 20.0,
+              right: 16.0,
+              bottom: 0.0)); // Check specific padding
+    });
+  });
+
+  group('PaddedChildrenList', () {
+    testWidgets('PaddedChildrenList applies default padding',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: PaddedChildrenList(
+            children: [Text('Child 1'), Text('Child 2')],
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(
+          padding.padding,
+          const EdgeInsets.only(
+              left: 16.0, right: 16.0, bottom: 16.0)); // Default padding
+    });
+
+    testWidgets('PaddedChildrenList applies all side padding',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PaddedChildrenList.all(
+            padding: 20.0,
+            children: const [Text('Child 1'), Text('Child 2')],
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(padding.padding, const EdgeInsets.all(20.0));
+    });
+
+    testWidgets('PaddedChildrenList applies symmetric padding',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PaddedChildrenList.symmetric(
+            vertical: 10.0,
+            horizontal: 20.0,
+            children: const [Text('Child 1'), Text('Child 2')],
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(padding.padding,
+          const EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0));
+    });
+
+    testWidgets('PaddingWrapper applies individual padding',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PaddingWrapper.only(
+            left: 10.0,
+            top: 20.0,
+            child: const Text('Test'),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(
+          padding.padding,
+          const EdgeInsets.only(
+              left: 10.0,
+              top: 20.0,
+              right: 16.0,
+              bottom: 0.0)); // Check specific padding
+    });
+  });
+}


### PR DESCRIPTION
### Refactor of `PaddedWidgets` to Improve Flexibility and Usability

#### Summary:
This PR refactors the `PaddingWrapper` and `PaddedChildrenList` widgets to enhance their flexibility, usability, and customization options. The main goal is to simplify the padding logic and provide factory constructors for common padding scenarios, allowing for quicker integration while maintaining control over layout customization.

#### Changes:
- **`PaddingWrapper`**:
  - Added factory constructors (`all`, `symmetric`, `only`, `vertical`, `horizontal`) to simplify the padding setup.
  - Default padding of `16.0` can be customized for each constructor.
  
- **`PaddedChildrenList`**:
  - Introduced factory constructors (`all`, `symmetric`, `only`) to allow customizable padding setups for lists.
  - Padding defaults to `16.0` for common use cases, but is easily adjustable.

#### Tests:
- Added unit tests to verify that padding is applied correctly in various configurations (default, symmetric, specific side paddings).
- Ensured that custom padding values are correctly reflected in both `PaddingWrapper` and `PaddedChildrenList`.

This refactor improves code readability, reduces boilerplate, and allows users to apply padding more intuitively across different widget setups.